### PR TITLE
[chore] Bump VVR connectors and OSS Flink version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ under the License.
 
     <groupId>com.alibaba.ververica</groupId>
     <artifactId>ververica-connector-demo</artifactId>
-    <version>1.17-vvr-8.0.4-1</version>
+    <version>1.17-vvr-8.0.11-1</version>
 
     <name>Ververica Connector Demo : </name>
 

--- a/ververica-connector-datahub-demo/pom.xml
+++ b/ververica-connector-datahub-demo/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.alibaba.ververica</groupId>
     <artifactId>ververica-connector-datahub-demo</artifactId>
-    <version>1.17-vvr-8.0.4-1</version>
+    <version>1.17-vvr-8.0.11-1</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.17.1</flink.version>
-        <vvr.version>1.17-vvr-8.0.4-1</vvr.version>
+        <flink.version>1.17.2</flink.version>
+        <vvr.version>1.17-vvr-8.0.11-1</vvr.version>
         <target.java.version>1.8</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>

--- a/ververica-connector-hologres-demo/pom.xml
+++ b/ververica-connector-hologres-demo/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.alibaba.ververica</groupId>
     <artifactId>ververica-connector-hologres-demo</artifactId>
-    <version>1.17-vvr-8.0.4-1</version>
+    <version>1.17-vvr-8.0.11-1</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.17.1</flink.version>
-        <vvr.version>1.17-vvr-8.0.4-1</vvr.version>
+        <flink.version>1.17.2</flink.version>
+        <vvr.version>1.17-vvr-8.0.11-1</vvr.version>
         <target.java.version>1.8</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>

--- a/ververica-connector-kafka-demo/pom.xml
+++ b/ververica-connector-kafka-demo/pom.xml
@@ -22,15 +22,15 @@ under the License.
 
     <groupId>com.alibaba.ververica</groupId>
     <artifactId>ververica-connector-kafka-demo</artifactId>
-    <version>1.17-vvr-8.0.4-1</version>
+    <version>1.17-vvr-8.0.11-1</version>
     <packaging>jar</packaging>
 
     <name>Ververica Connector Demo : Kafka</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.17.1</flink.version>
-        <vvr.version>1.17-vvr-8.0.4-1</vvr.version>
+        <flink.version>1.17.2</flink.version>
+        <vvr.version>1.17-vvr-8.0.11-1</vvr.version>
         <target.java.version>1.8</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>

--- a/ververica-connector-maxcompute-demo/pom.xml
+++ b/ververica-connector-maxcompute-demo/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.alibaba.ververica</groupId>
     <artifactId>ververica-connector-maxcompute-demo</artifactId>
-    <version>1.17-vvr-8.0.4-1</version>
+    <version>1.17-vvr-8.0.11-1</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.17.1</flink.version>
-        <vvr.version>1.17-vvr-8.0.4-1</vvr.version>
+        <flink.version>1.17.2</flink.version>
+        <vvr.version>1.17-vvr-8.0.11-1</vvr.version>
         <target.java.version>1.8</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>

--- a/ververica-connector-mysql-cdc-demo/pom.xml
+++ b/ververica-connector-mysql-cdc-demo/pom.xml
@@ -6,15 +6,15 @@
 
     <groupId>com.alibaba.ververica</groupId>
     <artifactId>ververica-connector-mysql-cdc-demo</artifactId>
-    <version>1.17-vvr-8.0.4-1</version>
+    <version>1.17-vvr-8.0.11-1</version>
     <packaging>jar</packaging>
 
     <name>Ververica Connector Demo : MySQL CDC</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.17.1</flink.version>
-        <vvr.version>1.17-vvr-8.0.4-1</vvr.version>
+        <flink.version>1.17.2</flink.version>
+        <vvr.version>1.17-vvr-8.0.11-1</vvr.version>
         <target.java.version>1.8</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>

--- a/ververica-connector-rocketmq-demo/pom.xml
+++ b/ververica-connector-rocketmq-demo/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.alibaba.ververica</groupId>
     <artifactId>ververica-connector-rocketmq-demo</artifactId>
-    <version>1.17-vvr-8.0.4-1</version>
+    <version>1.17-vvr-8.0.11-1</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.17.1</flink.version>
-        <vvr.version>1.17-vvr-8.0.4-1</vvr.version>
+        <flink.version>1.17.2</flink.version>
+        <vvr.version>1.17-vvr-8.0.11-1</vvr.version>
         <target.java.version>1.8</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>


### PR DESCRIPTION
This PR bumps VVR connectors version to latest 1.17-vvr-8.0.11-1, and OSS Flink version to 1.17.2.